### PR TITLE
fix: hadolint severity level and report trigger

### DIFF
--- a/.github/workflows/dockerfile-linter.yml
+++ b/.github/workflows/dockerfile-linter.yml
@@ -26,14 +26,16 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: hadolint/hadolint-action@v3.1.0
+        id: linter
         with:
           dockerfile: ${{ inputs.dockerfile_path }}
+          failure-threshold: warning
           output-file: test-report.json
           format: json
 
       - name: Update Pull Request
         uses: actions/github-script@v6
-        if: always()
+        if: failure() && steps.linter.outcome == 'failure'
         with:
           script: |
             const output = `


### PR DESCRIPTION
- hadolint step only fail if severity level is higher than `warning`
- hadolint report in PR comment only trigger if the previous linter fail