### PR TITLE
Add dedicated workflow to run pytest unit tests with coverage and test report

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,0 +1,80 @@
+name: 'Run Pytest'
+
+on:
+  workflow_call:
+    inputs:
+      image_url:
+        required: true
+        type: string
+      workdir:
+        required: true
+        type: string
+      run_command:
+        required: true
+        type: string
+      directory_to_test:
+        required: true
+        type: string
+      env_django_settings_module:
+        required: true
+        type: string
+      environment_name:
+        required: false
+        type: string
+
+jobs:
+  run-pytest:
+    runs-on: ubuntu-latest
+    permissions:
+        actions: write
+        checks: write
+        contents: write
+        id-token: write
+        pull-requests: write
+    environment:
+      name: ${{ inputs.environment_name }}
+    container:
+      image: ${{ inputs.image_url }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+      env:
+        DJANGO_SETTINGS_MODULE: ${{ inputs.env_django_settings_module }}
+        GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+        - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: run-command
+        working-directory: ${{ inputs.workdir }}
+        env:
+          POSTGRES_HOST: postgres
+          POSTGRES_PORT: 5432
+        run: |
+          pytest --verbose --cov --junit-xml reports/unit_tests_results.xml ${{ inputs.directory_to_test }}
+
+      - name: Test Report
+        uses: dorny/test-reporter@v1.9.1
+        id: test-report
+        with:
+          name: "UT Report"
+          path: ${{ inputs.workdir }}/reports/unit_tests_results.xml
+          working-directory: ${{ inputs.workdir }}
+          reporter: java-junit
+          max-annotations: 0
+          list-tests: 'failed'
+
+      - name: Coverage comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          COVERAGE_PATH: ./


### PR DESCRIPTION
Before we were using "run-docker-with-db" wich was very generic to allow many different usages beside unit testing, but this make the workflow way too complicated with many conditional steps.

This rework aims to reduce complexity by having a straightforward and dedicated workflow for unit tests