### PR TITLE
fix(run-pytest): Do not publish PR comment when build is not triggered from a PR

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3
+        if: github.event.workflow_run.event == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION

- py-cov-action/python-coverage-comment-action does not handle it and crash
- it does not make sens anyway