### PR TITLE
Init Dotnet workflows

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,0 +1,116 @@
+name: Dotnet - Build
+
+on:
+  workflow_call:
+    inputs:
+      dotnet_version:
+        required: false
+        type: string
+        default: "8.0.x"
+        description: "The dotnet version to use"
+      solution_name:
+        required: true
+        type: string
+        description: "The project SLN file name to use"
+      solution_configuration:
+        required: false
+        type: string
+        description: "The project configuration to use"
+        default: "Release"
+      packages_to_upload:
+        required: true
+        type: string
+        description: "The packages list to upload"
+      code_coverage_threshold:
+        required: false
+        type: string
+        description: "The code coverage threshold to use"
+        default: "60 80"
+      code_coverage_enabled:
+        required: false
+        type: boolean
+        description: "Whether to enable code coverage reporting"
+        default: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ inputs.dotnet_version }}
+
+      - name: Build solution
+        run: dotnet build ${{ inputs.solution_name }} --configuration ${{ inputs.solution_configuration }}
+
+      - name: Unit tests
+        run: >-
+          dotnet test ${{ inputs.solution_name }}
+          --no-build
+          --configuration ${{ inputs.solution_configuration }}
+          --settings .test-runsettings.xml
+          --logger "trx"
+
+      - name: Test Report - Unit Tests - Check Summary
+        uses: dorny/test-reporter@v1.9.1
+        if: always()
+        with:
+          name: Unit Tests Results
+          path: TestResults/**/*.trx
+          reporter: dotnet-trx
+
+      - name: Test Report - Unit Tests - PR Annotation
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: TestResults/**/*.trx
+          check_run: false # Use dorny test report
+          job_summary: false # Use dorny test report
+
+      - name: Combine Coverage Reports
+        if: inputs.code_coverage_enabled
+        uses: danielpalme/ReportGenerator-GitHub-Action@v5
+        with:
+          reports: "TestResults/**/*.cobertura.xml"
+          targetdir: "${{ github.workspace }}/Coverage"
+          reporttypes: "Cobertura"
+
+      - name: Code Coverage Report
+        if: inputs.code_coverage_enabled
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: Coverage/Cobertura.xml
+          badge: true
+          fail_below_min: true
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: ${{ inputs.code_coverage_threshold }}
+
+      - name: Add Coverage PR Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request' && inputs.code_coverage_enabled
+        with:
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Create package
+        run: dotnet pack ${{ inputs.solution_name }} --configuration ${{ inputs.solution_configuration }}
+
+      - name: Upload packages to GitHub Packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.solution_name }}-${{ inputs.solution_configuration }}
+          path: |
+            ${{ join(format('./{0}/bin/{1}', fromJSON(inputs.packages_to_upload), inputs.solution_configuration), '\n') }}

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -17,6 +17,11 @@ on:
         type: string
         description: "The project configuration to use"
         default: "Release"
+      solution_version_suffix:
+        required: false
+        type: string
+        description: "The project version suffix to use"
+        default: ""
       packages_to_upload:
         required: true
         type: string
@@ -40,6 +45,7 @@ jobs:
       issues: read
       checks: write
       pull-requests: write
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -105,12 +111,24 @@ jobs:
           recreate: true
           path: code-coverage-results.md
 
-      - name: Create package
-        run: dotnet pack ${{ inputs.solution_name }} --configuration ${{ inputs.solution_configuration }}
+      - name: Create Package
+        run: >-
+          dotnet pack ${{ inputs.solution_name }}
+          --configuration ${{ inputs.solution_configuration }}
+          --output packages
+          --version-suffix ${{ inputs.solution_version_suffix }}
 
-      - name: Upload packages to GitHub Packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.solution_name }}-${{ inputs.solution_configuration }}
-          path: |
-            ${{ join(format('./{0}/bin/{1}', fromJSON(inputs.packages_to_upload), inputs.solution_configuration), '\n') }}
+      - name: Login to Github Packages
+        run: >-
+          dotnet nuget add source
+          --username ${{ github.actor }}
+          --password ${{ secrets.GITHUB_TOKEN }}
+          --store-password-in-clear-text
+          --name github
+          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+      - name: Publish packages to Github Packages
+        run: >-
+          dotnet nuget push packages/*.nupkg
+          --source github
+          --skip-duplicate

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,0 +1,59 @@
+name: Dotnet - Publish
+
+on:
+  workflow_call:
+    inputs:
+      package_to_publish:
+        required: true
+        type: string
+        description: "The package to publish"
+      package_version:
+        required: true
+        type: string
+        description: "The package version to use"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: read
+    environment: main
+    env:
+      AWS_ACCOUNT_ID: ${{ inputs.AWS_ACCOUNT_ID || vars.AWS_ACCOUNT_ID }}
+      AWS_REGION: ${{ inputs.AWS_REGION || vars.AWS_REGION }}
+      CODEARTIFACT_DOMAIN: smartway
+      CODEARTIFACT_REPOSITORY: nuget-release
+    steps:
+      - name: Login to Github Packages
+        run: >-
+          nuget sources add
+          -Name github
+          -Source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          -Username ${{ github.actor }}
+          -Password ${{ secrets.GITHUB_TOKEN }}
+          -StorePasswordInClearText
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_oidc
+
+      - name: Login to CodeArtifact
+        run: "aws codeartifact login --tool dotnet --repository ${CODEARTIFACT_REPOSITORY} --domain ${CODEARTIFACT_DOMAIN} --domain-owner ${AWS_ACCOUNT_ID} --region ${AWS_REGION}"
+
+      - name: Download NuGet package
+        run: >-
+          nuget install ${{ inputs.package_to_publish }} 
+          -Version ${{ inputs.package_version }} 
+          -PackageSaveMode nupkg
+          -DirectDownload
+          -DependencyVersion Ignore
+          -Source github
+
+      - name: Publish package to AWS
+        run: >-
+          dotnet nuget push ${{ inputs.package_to_publish }}.${{ inputs.package_version }}/${{ inputs.package_to_publish }}.${{ inputs.package_version }}.nupkg
+          --source https://${{ env.CODEARTIFACT_DOMAIN }}-${{ env.AWS_ACCOUNT_ID }}.d.codeartifact.${{ env.AWS_REGION }}.amazonaws.com/nuget/${{ env.CODEARTIFACT_REPOSITORY }}/v3/index.json
+          --skip-duplicate

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -16,14 +16,18 @@ on:
         type: boolean
         description: "Whether to publish to the public registry"
         default: true
-
+      environment_name:
+        required: false
+        type: string
+        description: "The environment name to use"
+        default: main
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       packages: read
-    environment: main
+    environment: ${{ inputs.environment_name }}
     env:
       VAULT_URL: ${{ vars.VAULT_URL }}
       VAULT_GITHUB_ACTIONS_ROLE: ${{ vars.VAULT_GITHUB_ACTIONS_ROLE }}

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         description: "The package version to use"
+      publish_to_public_registry:
+        required: false
+        type: boolean
+        description: "Whether to publish to the public registry"
+        default: true
 
 jobs:
   publish:
@@ -20,6 +25,8 @@ jobs:
       packages: read
     environment: main
     env:
+      VAULT_URL: ${{ vars.VAULT_URL }}
+      VAULT_GITHUB_ACTIONS_ROLE: ${{ vars.VAULT_GITHUB_ACTIONS_ROLE }}
       AWS_ACCOUNT_ID: ${{ inputs.AWS_ACCOUNT_ID || vars.AWS_ACCOUNT_ID }}
       AWS_REGION: ${{ inputs.AWS_REGION || vars.AWS_REGION }}
       CODEARTIFACT_DOMAIN: smartway
@@ -40,6 +47,32 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_oidc
 
+      - name: Tailscale
+        if: inputs.publish_to_public_registry
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          version: ${{ vars.TAILSCALE_VERSION }}
+
+      - name: Import Secrets
+        if: inputs.publish_to_public_registry
+        uses: Wandalen/wretry.action@v3
+        id: secrets
+        with:
+          action: hashicorp/vault-action@v3
+          attempt_limit: 5
+          attempt_delay: 150
+          with: |
+            url: ${{ env.VAULT_URL }}
+            role: ${{ env.VAULT_GITHUB_ACTIONS_ROLE }}
+            method: jwt
+            path: "github-actions"
+            exportToken: true
+            secrets: |
+              secret/data/github-actions-common/nuget-registry api-key | NUGET_PUBLIC_API_KEY;
+
       - name: Login to CodeArtifact
         run: "aws codeartifact login --tool dotnet --repository ${CODEARTIFACT_REPOSITORY} --domain ${CODEARTIFACT_DOMAIN} --domain-owner ${AWS_ACCOUNT_ID} --region ${AWS_REGION}"
 
@@ -56,4 +89,12 @@ jobs:
         run: >-
           dotnet nuget push ${{ inputs.package_to_publish }}.${{ inputs.package_version }}/${{ inputs.package_to_publish }}.${{ inputs.package_version }}.nupkg
           --source https://${{ env.CODEARTIFACT_DOMAIN }}-${{ env.AWS_ACCOUNT_ID }}.d.codeartifact.${{ env.AWS_REGION }}.amazonaws.com/nuget/${{ env.CODEARTIFACT_REPOSITORY }}/v3/index.json
+          --skip-duplicate
+
+      - name: Publish package to Public Registry
+        if: inputs.publish_to_public_registry
+        run: >-
+          dotnet nuget push ${{ inputs.package_to_publish }}.${{ inputs.package_version }}/${{ inputs.package_to_publish }}.${{ inputs.package_version }}.nupkg
+          --source https://api.nuget.org/v3/index.json
+          --api-key ${{ fromJSON( steps.secrets.outputs.outputs ).NUGET_PUBLIC_API_KEY }}
           --skip-duplicate


### PR DESCRIPTION
Init Dotnet workflows
- Build and test workflow
- Publish workflow to public and private AWS nuget registries

### Build workflow : 
- Build dotnet project
- Unit test and coverage
- Pack in nuget 
- Upload to Github Packages in Nuget registry

### Publish workflow : 
- Pull from Github Packages
- Push to AWS and Nuget Public registry (Avoid breaking change to not  publish in public one for the moment) 