### PR TITLE
fix: support multiline-inputs for dotnet_version args

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -6,7 +6,8 @@ on:
       dotnet_version:
         required: false
         type: string
-        default: "8.0.x"
+        default: |
+          8.0.x
         description: "The dotnet version to use"
       solution_name:
         required: true


### PR DESCRIPTION
Lors du refacto pour les projets dotnet le setup multi version de dotnet a disparu.
Ca nous bloque car nos librairies sont buildées pour Xamarin (.netStandard) et .Net8.
Le commit en question https://github.com/ZeroGachis/Smartway.Printers/commit/1471efeffdad7df033af9a422ab65ead78b946a6
