### PR TITLE
fix: condition on trivy sarif edit job

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -284,6 +284,7 @@ jobs:
           TRIVY_DISABLE_VEX_NOTICE: true
 
       - name: Edit Trivy Sarif result
+        if: inputs.security_scan_enabled && inputs.security_scan_output_format == 'sarif'
         run: |
           jq ".runs[0].tool.driver.name = \"Trivy-image-${{ inputs.image_name }}\"" ./trivy-results-${{ inputs.image_name }}.sarif > ./trivy-results-${{ inputs.image_name }}-edited.sarif
 


### PR DESCRIPTION
the edit sarif job is alway running and throw errors when there is no scan prior
https://github.com/ZeroGachis/base-docker-images/actions/runs/15670055241/job/44139572519?pr=344