### PR TITLE
chore(security_scan): add capability to run into Gotoprod workflow

### DIFF
--- a/.github/workflows/create-gotoprod-pr.yml
+++ b/.github/workflows/create-gotoprod-pr.yml
@@ -8,6 +8,10 @@ on:
         type: string
         required: false
         default: "main"
+    outputs:
+      pr_number:
+        description: "PR number created"
+        value: ${{ jobs.create_pr.outputs.pr_number }}
 
 jobs:
   create_pr:
@@ -15,11 +19,15 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
+    outputs:
+      pr_number: ${{ steps.create_pr.outputs.pr_number }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Create Pull Request
+        id: create_pr
         uses: actions/github-script@v7
         with:
           script: |
@@ -155,12 +163,17 @@ jobs:
                 issue_number: prNumber,
                 labels: ['go-to-prod', ':robot: automated-pr']
               });
-              github.rest.issues.updateLabel({
+              await github.rest.issues.updateLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 name: 'go-to-prod',
                 color: 'ff7f00'
               });
+
+              // Set output for the PR number to be used by subsequent steps
+              core.setOutput('pr_number', prNumber.toString());
+              console.log(`PR #${prNumber} created/updated successfully`);
             } catch (error) {
               console.error('Failed to create or update PR:', error);
             }
+

--- a/.github/workflows/security_scan_repo.yml
+++ b/.github/workflows/security_scan_repo.yml
@@ -11,6 +11,11 @@ on:
       - tools
       - release/*
   workflow_call:
+    inputs:
+      pr_number:
+        description: 'Pull request number to scan'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -25,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # If triggered via workflow_dispatch with PR number, checkout the PR branch
+          ref: ${{ github.event.inputs.pr_number && format('refs/pull/{0}/head', github.event.inputs.pr_number) || github.ref }}
 
       - name: Security Scan FS
         uses: aquasecurity/trivy-action@0.32.0

--- a/workflow-templates/gotoprod-pr.yml
+++ b/workflow-templates/gotoprod-pr.yml
@@ -6,9 +6,20 @@ on:
       - develop
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
+  actions: write
+  checks: write
+  security-events: write
 
 jobs:
   call-gotoprod-pr-workflow:
     uses: ZeroGachis/.github/.github/workflows/create-gotoprod-pr.yml@v4
+  security_scan:
+    needs: call-gotoprod-pr-workflow
+    if: needs.call-gotoprod-pr-workflow.outputs.pr_number != ''
+    uses: ZeroGachis/.github/.github/workflows/security_scan_repo.yml@v4
+    with:
+      pr_number: ${{ needs.call-gotoprod-pr-workflow.outputs.pr_number }}
+    secrets: inherit


### PR DESCRIPTION
We faced an issue when GoToProd PR is created, other workflow can be triggered it's a Github rule, we need to run it manually