### PR TITLE
fix: security-scan workflow should always run notify-alerts

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -48,6 +48,7 @@ jobs:
 
   notify-alerts:
     needs: [scan-image, scan-iac, scan-filesystem]
+    if: ${{ always() }}
     uses: ZeroGachis/.github/.github/workflows/security-scan-notify-alerts.yml@main
     secrets: inherit
     with:


### PR DESCRIPTION
Previously, If a user disabled a jobs (ex: scan-filesystem) the job notify-alerts would not be triggered.

What we actually want is to always run the notify-alerts jobs, but only run it when scan-image, scan-iac and scan-filesystem are done if they were enabled.