### PR TITLE
fix: Allow to skip files during the filesystem scan

### DIFF
--- a/.github/workflows/security-scan-filesystem.yml
+++ b/.github/workflows/security-scan-filesystem.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
         default: "0"
+      skip-files:
+        description: "Comma-separated list of file to skip during the scan"
+        required: false
+        type: string
 
 jobs:
   security-scan-filesystem:
@@ -35,6 +39,7 @@ jobs:
           output: "trivy-results-filesystem.sarif"
           severity: ${{ inputs.severity }}
           exit-code: ${{ inputs.exit-code }}
+          skip-files: ${{ inputs.skip-files }}
 
       # Rename the tool driver to Trivy-image-and-fs so it appears in GitHub Security tab
       # in the same panel for trivy image and trivy fs reports

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: "critical"
+      skip-files:
+        description: "Comma-separated list of file to skip during the scan"
+        required: false
+        type: string
 
 jobs:
   validate-scan-image-inputs:
@@ -55,6 +59,8 @@ jobs:
     uses: ZeroGachis/.github/.github/workflows/security-scan-filesystem.yml@main
     if: ${{ inputs.scan-filesystem }}
     secrets: inherit
+    with:
+      skip-files: ${{ inputs.skip-files }}
 
   notify-alerts:
     needs: [scan-image, scan-iac, scan-filesystem]


### PR DESCRIPTION
Useful to skip a lock file when scanning a library