### PR TITLE
fix: Allow to disable using org-level vulnerability ignore rules

### DIFF
--- a/.github/actions/get-trivy-ignore-rules/action.yml
+++ b/.github/actions/get-trivy-ignore-rules/action.yml
@@ -7,13 +7,13 @@ inputs:
   smartway_github_bot_private_key:
     description: "Smartway's Github bot private key"
     required: true
-  org-docker-image-ignore-rules:
-    description: Add ZeroGachis/base-docker-images .trivyignore in the final .trivyignore file
+  use-org-docker-image-ignore-rules:
+    description: Use org-level vulnerability ignore rules when scanning an image (fetched from ZeroGachis/base-docker-images's .trivyignore)
     required: false
     type: boolean
     default: false
-  org-iac-ignore-rules:
-    description: Add ZeroGachis/platform-core .trivyignore in the final .trivyignore file
+  use-org-iac-ignore-rules:
+    description: Use org-level vulnerability ignore rules when scanning IaC config (fetched from ZeroGachis/platform-core's .trivyignore)
     required: false
     type: boolean
     default: false
@@ -35,7 +35,7 @@ runs:
     - name: Generate GitHub App Token to access ZeroGachis/base-docker-images
       uses: actions/create-github-app-token@v3
       id: base-docker-images-app-token
-      if: ${{ inputs.org-docker-image-ignore-rules == 'true' }}
+      if: ${{ inputs.use-org-docker-image-ignore-rules == 'true' }}
       with:
         client-id: ${{ inputs.smartway_github_bot_id }}
         private-key: ${{ inputs.smartway_github_bot_private_key }}
@@ -44,7 +44,7 @@ runs:
     
     - name: Fetch .trivyignore of ZeroGachis/base-docker-images main branch
       uses: actions/checkout@v6
-      if: ${{ inputs.org-docker-image-ignore-rules == 'true' }}
+      if: ${{ inputs.use-org-docker-image-ignore-rules == 'true' }}
       with:
         repository: ZeroGachis/base-docker-images
         ref: main
@@ -54,7 +54,7 @@ runs:
         token: ${{ steps.base-docker-images-app-token.outputs.token }}
 
     - name: Generate GitHub App Token to access ZeroGachis/platform-core
-      if: ${{ inputs.org-iac-ignore-rules == 'true' }}
+      if: ${{ inputs.use-org-iac-ignore-rules == 'true' }}
       uses: actions/create-github-app-token@v3
       id: platform-core-app-token
       with:
@@ -65,7 +65,7 @@ runs:
 
     - name: Fetch .trivyignore of ZeroGachis/platform-core main branch
       uses: actions/checkout@v6
-      if: ${{ inputs.org-iac-ignore-rules == 'true' }}
+      if: ${{ inputs.use-org-iac-ignore-rules == 'true' }}
       with:
         repository: ZeroGachis/platform-core
         ref: main

--- a/.github/workflows/security-scan-iac.yml
+++ b/.github/workflows/security-scan-iac.yml
@@ -13,6 +13,12 @@ on:
         required: false
         type: string
         default: "0"
+      use-org-iac-ignore-rules:
+        description: Use org-level vulnerability ignore rules when scanning IaC config
+        required: false
+        type: boolean
+        default: true
+
 
 jobs:
   security-scan-iac:
@@ -32,7 +38,7 @@ jobs:
         with:
           smartway_github_bot_id: ${{ secrets.SW_BOT_APP_ID }}
           smartway_github_bot_private_key: ${{ secrets.SW_BOT_APP_PRIVATE_KEY }}
-          org-iac-ignore-rules: true
+          use-org-iac-ignore-rules: ${{ inputs.use-org-iac-ignore-rules }}
 
       - name: Output .trivyignore file
         run: |

--- a/.github/workflows/security-scan-image.yml
+++ b/.github/workflows/security-scan-image.yml
@@ -30,6 +30,11 @@ on:
         description: AWS region to use for ECR authentication
         required: false
         type: string
+      use-org-docker-image-ignore-rules:
+        description: Use org-level vulnerability ignore rules when scanning an image
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   security-scan-image:
@@ -65,7 +70,7 @@ jobs:
         with:
           smartway_github_bot_id: ${{ secrets.SW_BOT_APP_ID }}
           smartway_github_bot_private_key: ${{ secrets.SW_BOT_APP_PRIVATE_KEY }}
-          org-docker-image-ignore-rules: true
+          use-org-docker-image-ignore-rules: ${{ inputs.use-org-docker-image-ignore-rules }}
 
       - name: Output .trivyignore file
         run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,6 +39,14 @@ on:
         description: AWS region to use for ECR authentication
         required: false
         type: string
+      use-org-docker-image-ignore-rules:
+        description: Use org-level vulnerability ignore rules when scanning an image
+        required: false
+        type: boolean
+      use-org-iac-ignore-rules:
+        description: Use org-level vulnerability ignore rules when scanning IaC config
+        required: false
+        type: boolean
 
 jobs:
   validate-scan-image-inputs:
@@ -58,12 +66,16 @@ jobs:
       repository: ${{ inputs.repository }}
       aws_account_id: ${{ inputs.aws_account_id }}
       aws_region: ${{ inputs.aws_region }}
+      use-org-docker-image-ignore-rules: ${{ inputs.use-org-docker-image-ignore-rules }}
     secrets: inherit
 
   scan-iac:
     uses: ZeroGachis/.github/.github/workflows/security-scan-iac.yml@main
     if: ${{ inputs.scan-iac }}
     secrets: inherit
+    with:
+      use-org-iac-ignore-rules: ${{ inputs.use-org-iac-ignore-rules }}
+
 
   scan-filesystem:
     uses: ZeroGachis/.github/.github/workflows/security-scan-filesystem.yml@main


### PR DESCRIPTION
Useful for public repository where we don't want to access (and expose) the vulnerability we ignore.