### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -165,14 +165,14 @@ jobs:
 
       - name: Configure AWS Credentials
         id: aws
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: eu-west-3
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_oidc_readonly
           output-credentials: true
 
       - name: Login to Github Packages
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.regitry_url }}
           username: ${{ github.actor }}
@@ -186,7 +186,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.regitry_url }}/${{ github.repository_owner	 }}/${{ inputs.image_name }}
           labels: |
@@ -196,7 +196,7 @@ jobs:
             latest=false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Lint Dockerfile - Hadolint
         if: inputs.linter_tool == 'hadolint'
@@ -208,7 +208,7 @@ jobs:
           hadolint_ignore: DL3002 DL3008
 
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: ${{ inputs.dockerfile_context }}

--- a/.github/workflows/build-push-image-to-dockerhub.yml
+++ b/.github/workflows/build-push-image-to-dockerhub.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ vars.DOCKERHUB_USERNAME }}/${{ inputs.dockerhub_repository_name }}
           tags: ${{ steps.tags.outputs.tags }}
@@ -60,10 +60,10 @@ jobs:
             latest=false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: ${{ inputs.dockerfile_context }}

--- a/.github/workflows/build-xamarin-lib.yml
+++ b/.github/workflows/build-xamarin-lib.yml
@@ -37,7 +37,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/${{ inputs.aws-github-role-name }}
           aws-region: ${{ inputs.aws-ecr-region }}

--- a/.github/workflows/create-apk-artifact.yml
+++ b/.github/workflows/create-apk-artifact.yml
@@ -145,7 +145,7 @@ jobs:
             secret/data/smartapp/keystore S3_BUCKET | KEYSTORE_BUCKET_S3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}
@@ -279,7 +279,7 @@ jobs:
           SMARTWAY_KEYSTORE_NAME: ${{ env.smartway_keystore_name }}
 
       - name: Upload Apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Apk-${{ inputs.configuration }}
           path: ${{ inputs.working-directory }}/android/app/build/outputs/apk/${{ inputs.configuration }}/${{ env.apk_name }}

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -46,7 +46,7 @@ jobs:
           -StorePasswordInClearText
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_oidc

--- a/.github/workflows/fetch-terraform-output.yml
+++ b/.github/workflows/fetch-terraform-output.yml
@@ -46,7 +46,7 @@ jobs:
       TF_OUTPUT_VAR: ${{ steps.set-variables.outputs.tf_output_var }}
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}

--- a/.github/workflows/publish-apk-s3.yml
+++ b/.github/workflows/publish-apk-s3.yml
@@ -103,7 +103,7 @@ jobs:
             secret/data/${{ inputs.vault-path }} S3_APP_BUCKET | S3_APP_BUCKET ;
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}

--- a/.github/workflows/push-image-ghcr-to-ecr.yml
+++ b/.github/workflows/push-image-ghcr-to-ecr.yml
@@ -50,7 +50,7 @@ jobs:
       steps:
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         id: creds
         with:
           aws-region: ${{ env.AWS_REGION }}
@@ -58,14 +58,14 @@ jobs:
           output-credentials: true
 
       - name: Login to ECR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         env:
           ECR_DEFAULT_URL: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
         with:
           registry: ${{ inputs.ecr_url || env.ECR_DEFAULT_URL }}
 
       - name: Login to Github Packages
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,7 +43,7 @@ jobs:
           cache: 'pip'
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_oidc

--- a/.github/workflows/run-aws.yml
+++ b/.github/workflows/run-aws.yml
@@ -105,7 +105,7 @@ jobs:
             ${{ inputs.vault_secrets }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}

--- a/.github/workflows/run-dbt-tests.yml
+++ b/.github/workflows/run-dbt-tests.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: ${{ inputs.aws_credentials_enabled }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}
           aws-region: eu-west-1

--- a/.github/workflows/run-docker-upload-artifact.yml
+++ b/.github/workflows/run-docker-upload-artifact.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: inputs.aws_credentials_enabled
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}
@@ -148,7 +148,7 @@ jobs:
         run: ${{ inputs.run_command }}
 
       - name: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.workdir }}/${{ inputs.artifact_path }}

--- a/.github/workflows/run-docker-with-db.yml
+++ b/.github/workflows/run-docker-with-db.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: inputs.aws_credentials_enabled
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}

--- a/.github/workflows/run-docker.yml
+++ b/.github/workflows/run-docker.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: inputs.aws_credentials_enabled
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}

--- a/.github/workflows/run-python.yml
+++ b/.github/workflows/run-python.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: inputs.aws_credentials_enabled
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}

--- a/.github/workflows/security-scan-image.yml
+++ b/.github/workflows/security-scan-image.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Configure AWS Credentials
         id: aws
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/github_oidc_readonly

--- a/.github/workflows/structuretest-docker-image.yml
+++ b/.github/workflows/structuretest-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to Github Packages
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -180,7 +180,7 @@ jobs:
           secrets: |
             secret/data/github-actions-common/argocd apikey | ARGOCD_AUTH_TOKEN;
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ inputs.terraform_version }}
 
@@ -188,13 +188,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}
 
       - name: Get tiers Tools credentials
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
         with:
           secret-ids: |
             ${{ inputs.aws_secrets || env.AWS_DEFAULT_SECRETS }}
@@ -242,7 +242,7 @@ jobs:
         run: terraform output -json > tf-output.json
 
       - name: Save Output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: inputs.terraform_save_output
         with:
           name: tf-output-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}

--- a/.github/workflows/upload-dbt-manifest.yml
+++ b/.github/workflows/upload-dbt-manifest.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Configure AWS Credentials
         if: ${{ inputs.aws_credentials_enabled }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/${{ inputs.aws_github_role_name }}
           aws-region: eu-west-1


### PR DESCRIPTION
## Summary

Bump GitHub Actions versions that were still running on Node.js 20, before the deprecation deadline:
- **Node.js 20 forced on all runners** starting June 2, 2026
- **Node.js 20 removed** on September 16, 2026

| Action | Before | After | Renovate PR |
|---|---|---|---|
| `aws-actions/configure-aws-credentials` | v5 | v6 | #417 |
| `aws-actions/aws-secretsmanager-get-secrets` | v2 | v3 | #533 |
| `hashicorp/setup-terraform` | v3 | v4 | #448 |
| `actions/upload-artifact` | v4 | v7 | #392 |
| `docker/login-action` | v3 | v4 | #452 |
| `docker/metadata-action` | v5 | v6 | #453 |
| `docker/setup-buildx-action` | v3 | v4 | #454 |
| `docker/build-push-action` | v6 | v7 | #451 |

19 files updated. `hashicorp/vault-action@v3` left unchanged (no v4 available).

Merging this PR will make the above Renovate PRs redundant and they can be closed.

## Test plan

- [ ] No Node.js 20 deprecation warnings on the next run of **n8n** (uses `build-image`, `terraform`, `push-image-ghcr-to-ecr`)
- [ ] No Node.js 20 deprecation warnings on the next run of **order-service** (uses `build-image`, `run-docker-with-db`, `terraform`, `push-image-ghcr-to-ecr`, `fetch-terraform-output`, `run-aws`)