### PR TITLE
fix: security-scan workflow should ignore unfixed vulnerabilities to reduce noise

### DIFF
--- a/.github/workflows/security-scan-filesystem.yml
+++ b/.github/workflows/security-scan-filesystem.yml
@@ -40,6 +40,7 @@ jobs:
           severity: ${{ inputs.severity }}
           exit-code: ${{ inputs.exit-code }}
           skip-files: ${{ inputs.skip-files }}
+          ignore-unfixed: true
 
       # Rename the tool driver to Trivy-image-and-fs so it appears in GitHub Security tab
       # in the same panel for trivy image and trivy fs reports

--- a/.github/workflows/security-scan-iac.yml
+++ b/.github/workflows/security-scan-iac.yml
@@ -57,6 +57,7 @@ jobs:
           severity: ${{ inputs.severity }}
           exit-code: ${{ inputs.exit-code }}
           trivyignores: ".trivyignore-final"
+          ignore-unfixed: true
 
       # Rename the tool driver to Trivy-config so it appears distinctly in GitHub Security tab, separate from Trivy-repo & Trivy-image
       - name: Edit IaC configuration analysis

--- a/.github/workflows/security-scan-image.yml
+++ b/.github/workflows/security-scan-image.yml
@@ -92,6 +92,7 @@ jobs:
           severity: ${{ inputs.severity }}
           exit-code: ${{ inputs.exit-code }}
           trivyignores: ".trivyignore-final"
+          ignore-unfixed: true
 
       # Rename the tool driver to Trivy-image-and-fs so it appears in GitHub Security tab
       # in the same panel for trivy image and trivy fs reports


### PR DESCRIPTION
Typical case:

Right now, the Vault CLI has 3 CVEs (CVE-2026-3605, CVE-2026-4525 and CVE-2026-5807) where no fix is available. Without the --ignore-unfixed flag, we would be notified about these error but our only viable solution would be to just ignore them (by adding them in a .trivyignore file).

Solution:

The flag `--ignore-unfixed` is equivalent to `--ignore-status affected,will_not_fix,fix_deferred,end_of_life`

- `affected`: this package is affected by this vulnerability on this platform, but there is no patch released yet.
- `will_not_fix`: this package is affected by this vulnerability on this platform, but there is currently no intention to fix it (this would primarily be for flaws that are of Low or Moderate impact that pose no significant risk to customers)
- `fix_deferred`: this package is affected by this vulnerability on this platform, and may be fixed in the future
- `end_of_life``: this package has been identified to contain the impacted component, but analysis to determine whether it is affected or not by this vulnerability was not performed

Cf: https://trivy.dev/docs/latest/configuration/filtering/#by-status
