### PR TITLE
fix: Bump trivy from 0.69.3 to 0.70.0

### DIFF
--- a/.github/workflows/security-scan-filesystem.yml
+++ b/.github/workflows/security-scan-filesystem.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Analyze filesystem
         uses: aquasecurity/trivy-action@v0.35.0
         with:
-          version: v0.69.3 # Further 0.69 releases were compromised: https://github.com/aquasecurity/trivy/discussions/10425
+          version: v0.70.0
           scan-type: "fs"
           format: "sarif"
           output: "trivy-results-filesystem.sarif"

--- a/.github/workflows/security-scan-iac.yml
+++ b/.github/workflows/security-scan-iac.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Analyze IaC configuration
         uses: aquasecurity/trivy-action@v0.35.0
         with:
-          version: v0.69.3 # Further 0.69 releases were compromised: https://github.com/aquasecurity/trivy/discussions/10425
+          version: v0.70.0
           scan-type: "config"
           format: "sarif"
           output: "trivy-results-iac.sarif"

--- a/.github/workflows/security-scan-image.yml
+++ b/.github/workflows/security-scan-image.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           ECR_DEFAULT_URL: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
         with:
-          version: v0.69.3 # Further 0.69 releases were compromised: https://github.com/aquasecurity/trivy/discussions/10425
+          version: v0.70.0
           scan-type: "image"
           image-ref: ${{ env.ECR_DEFAULT_URL }}/${{ inputs.repository }}:${{ inputs.release-tag }}
           format: "sarif"


### PR DESCRIPTION
The 0.70.0 release contains a fix where trivy would crash if it encounters a pyproject.toml file with an optional dependency group that contains no dependencies.

Cf: https://github.com/aquasecurity/trivy/pull/10359

A typical case is when you move from poetry specific dependency group definition to use the standard from PEP 735. The PEP 735 does not allow to defined optional dependency group so we still have to rely on poetry's specific syntax.

```pyproject.toml
[project]
name = "tasking-service"

[dependency-groups]
ci = ["pytest-github-actions-annotate-failures (~=0.4)", "pytest-cov (~=7.0)"]

[tool.poetry.group.ci]
optional = true
```

Ps: The 0.69.4 release was compromised.