### PR TITLE
fix: Re-install python dependencies when the python installed version changed

### DIFF
--- a/.github/actions/poetry-install/action.yml
+++ b/.github/actions/poetry-install/action.yml
@@ -24,12 +24,15 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve Python version
+      id: python-version
+      run: echo "version=$(python -c 'import platform; print(platform.python_version())')" >> "$GITHUB_OUTPUT"
     - name: Define a cache for the virtual environment based on the dependencies lock file
       uses: actions/cache@v5
       id: cache-python-deps
       with:
         path: ./.venv
-        key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ inputs.install_options }}
+        key: venv-${{ runner.os }}-py${{ steps.python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}-${{ inputs.install_options }}
     - name: Authenticate on AWS
       if: inputs.depends_on_private_packages == 'true' && steps.cache-python-deps.outputs.cache-hit != 'true'
       id: aws


### PR DESCRIPTION
A virtualenv holds a symlink to the python version installed when it was created. Generally, project constraint python version loosely in their mise config file used to install python on CI (like: python: 3.14 instead of python: 3.14.5).

The case happened today:

On tasking-service, python 3.14.5 was installed and cached on CI and a virtualenv created with this python version was also cached too.

The 10 june Python 3.14.6 was released.

Today (12 june), I ran a CI build which triggered to install Python 3.14.6. The python virtualenv was fetched from cache, but it referenced Python 3.14.5 which means an error indicating that the virtualenv is broken appeared when running a python CLI like "ruff".

Ping @ulricden 